### PR TITLE
Fix typo "optionnal"

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,14 +438,14 @@ const countryFields = getRequiredFields("US");
 ["state", "zip", "city", "addressLine1"]
 ```
 
-#### getOptionnalFields
+#### getOptionalFields
 
-Returns an array of optionnal fields for a country.
+Returns an array of optional fields for a country.
 
 ```ts
-import { getOptionnalFields } from "lib-address";
+import { getOptionalFields } from "lib-address";
 
-const countryFields = getOptionnalFields("US");
+const countryFields = getOptionalFields("US");
 ```
 
 ```json


### PR DESCRIPTION
Hi Lancelot,

Thank you very much for this excellent library!

This PR fixes a small typo in the README.
Indeed, "optional" takes only one "n" in English (unlike in French, where "optionnel" takes two).

Keep up the good work!

Best regards,
Benoit